### PR TITLE
Pico updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub struct Api {
 	///
 	/// If the region number given is invalid, the function returns `(null,
 	/// 0)`.
-	pub memory_get_region: extern "C" fn(region: u8) -> (*mut u8, usize),
+	pub memory_get_region: extern "C" fn(region: u8, out_start: *mut *mut u8, out_len: *mut usize) -> crate::Result<()>,
 }
 
 // End of file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,11 @@ pub struct Api {
 	///
 	/// If the region number given is invalid, the function returns `(null,
 	/// 0)`.
-	pub memory_get_region: extern "C" fn(region: u8, out_start: *mut *mut u8, out_len: *mut usize) -> crate::Result<()>,
+	pub memory_get_region: extern "C" fn(
+		region: u8,
+		out_start: *mut *mut u8,
+		out_len: *mut usize,
+	) -> crate::Result<()>,
 }
 
 // End of file

--- a/src/types.rs
+++ b/src/types.rs
@@ -120,11 +120,10 @@ pub struct ApiBuffer<'a> {
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct Time {
-	/// Seconds since 2000-01-01T00:00:00Z
-	pub seconds_since_epoch: u32,
-	/// Number of 60 Hz frames that have elapsed since the current second
-	/// began [0..59].
-	pub frames_since_second: u8,
+	/// Seconds since the epoch
+	pub secs: u32,
+	/// Nanoseconds since the last second rolled over
+	pub nsecs: u32
 }
 
 // ============================================================================
@@ -290,13 +289,19 @@ impl<'a> From<&'a mut [u8]> for ApiBuffer<'a> {
 
 impl core::fmt::Display for Time {
 	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error> {
+		let timestamp: chrono::DateTime<chrono::Utc> = self.into();
+		write!(f, "{}", timestamp)
+	}
+}
+
+impl From<&Time> for chrono::DateTime<chrono::Utc> {
+	fn from(time: &Time) -> Self {
 		use chrono::prelude::*;
 		let our_epoch = Utc.ymd(2001, 1, 1).and_hms(0, 0, 0).timestamp();
-		let time = chrono::Utc.timestamp(
-			i64::from(self.seconds_since_epoch) + our_epoch,
-			((u32::from(self.frames_since_second) * 1_000_000) / 60) * 1_000,
-		);
-		write!(f, "{}", time)
+		chrono::Utc.timestamp(
+			i64::from(time.secs) + our_epoch,
+			time.nsecs
+		)
 	}
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -123,7 +123,7 @@ pub struct Time {
 	/// Seconds since the epoch
 	pub secs: u32,
 	/// Nanoseconds since the last second rolled over
-	pub nsecs: u32
+	pub nsecs: u32,
 }
 
 // ============================================================================
@@ -298,10 +298,7 @@ impl From<&Time> for chrono::DateTime<chrono::Utc> {
 	fn from(time: &Time) -> Self {
 		use chrono::prelude::*;
 		let our_epoch = Utc.ymd(2001, 1, 1).and_hms(0, 0, 0).timestamp();
-		chrono::Utc.timestamp(
-			i64::from(time.secs) + our_epoch,
-			time.nsecs
-		)
+		chrono::Utc.timestamp(i64::from(time.secs) + our_epoch, time.nsecs)
 	}
 }
 

--- a/src/video.rs
+++ b/src/video.rs
@@ -42,7 +42,7 @@
 /// A Neotron BIOS may support multiple video modes. Each is described using
 /// an instance of this type.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Mode(u8);
 
 /// Describes the format of the video memory.

--- a/src/video.rs
+++ b/src/video.rs
@@ -187,6 +187,25 @@ impl Mode {
 		}
 	}
 
+	/// Gets how big a line is in glyph-attribute pairs.
+	pub const fn text_width(self) -> Option<u16> {
+		let horizontal_pixels = self.horizontal_pixels();
+
+		match self.format() {
+			Format::Text8x8 | Format::Text8x16 => Some(horizontal_pixels / 8),
+			_ => None,
+		}
+	}
+
+	/// Gets how many rows of text are on screen.
+	pub const fn text_height(self) -> Option<u16> {
+		match self.format() {
+			Format::Text8x8 => Some(self.vertical_lines() / 8),
+			Format::Text8x16 => Some(self.vertical_lines() / 16),
+			_ => None,
+		}
+	}
+
 	/// Gets how big the frame is, in bytes.
 	pub const fn frame_size_bytes(self) -> usize {
 		let line_size = self.line_size_bytes();


### PR DESCRIPTION
Time is now `secs, nsecs` because not all frame ticks are 60 Hz.
Mode can now tell you width and height for text mode, and impls `Eq`
Fixed `memory_get_region` to be FFI safe