### PR TITLE
API fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ dual licensed as above, without any additional terms or conditions.
 * Add `bus_interrupt_status`
 * Remove `delay`
 * Add back in the `block_XXX` API for reading/writing Block Devices.
+* Add idle function.
+* `memory_get_region` returns `Option`, not `Result`
 
 ### v0.6.1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -579,6 +579,15 @@ pub struct Api {
 		num_blocks: u8,
 		data: ApiByteSlice,
 	) -> crate::Result<()>,
+
+	// ========================================================================
+	// Power management functions
+	// ========================================================================
+	/// The OS will call this function when it's idle.
+	///
+	/// On a microcontroller, this will wait for interrupts. Running in an
+	/// emulator, this will sleep the thread for a while.
+	pub power_idle: extern "C" fn(),
 }
 
 // ============================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,7 @@ pub struct Api {
 	/// (if any), or from the top of Region 0 (although this reduces the maximum
 	/// application space available). The OS will prefer lower numbered regions
 	/// (other than Region 0), so faster memory should be listed first.
-	pub memory_get_region: extern "C" fn(region_index: u8) -> crate::Result<types::MemoryRegion>,
+	pub memory_get_region: extern "C" fn(region_index: u8) -> crate::Option<types::MemoryRegion>,
 
 	// ========================================================================
 	// Human Interface Device Support


### PR DESCRIPTION
* [memory_get_region can't fail - return an Option.](https://github.com/Neotron-Compute/Neotron-Common-BIOS/commit/b94fb18e398f57d2681e5f6c3d32c3024873f97e)
* [Add idle function.](https://github.com/Neotron-Compute/Neotron-Common-BIOS/commit/1cdc9a9eeaa6e3ba5ba16276495b5ed211644a60)

Useful to lower power draw when running on a Desktop App.