### PR TITLE
Add StackUsed and StackFree as memory types. Use FFI-safe types.

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -24,7 +24,7 @@
 // Imports
 // ============================================================================
 
-// None
+use crate::make_ffi_enum;
 
 // ============================================================================
 // Constants
@@ -36,26 +36,24 @@
 // Types
 // ============================================================================
 
-/// Defines the format of each sample (mono, stereo, 8-bit, 16-bit, etc).
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum SampleFormat {
-	/// 8-bit, signed, mono samples.
+make_ffi_enum!("Defines the format of each sample (mono, stereo, 8-bit, 16-bit, etc).",
+	SampleFormat, FfiSampleFormat, {
+	#[doc = "8-bit, signed, mono samples"]
 	EightBitMono,
-	/// 8-bit, signed, mono samples. Left, then Right.
+	#[doc = "8-bit, signed, mono samples. Left, then Right"]
 	EightBitStereo,
-	/// 16-bit, signed, mono samples. Little-endian.
+	#[doc = "16-bit, signed, mono samples. Little-endian"]
 	SixteenBitMono,
-	/// 16-bit, signed, stereo samples. Little-endian. Left, then Right.
-	SixteenBitStereo,
-}
+	#[doc = "16-bit, signed, stereo samples. Little-endian. Left, then Right"]
+	SixteenBitStereo
+});
 
 /// Configuration for an Audio Output or Input
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
 	/// What format are the samples
-	pub sample_format: SampleFormat,
+	pub sample_format: FfiSampleFormat,
 	/// How many samples are there per second (e.g. 48,000)?
 	///
 	/// Supported values are likely to include some of the following:
@@ -70,17 +68,15 @@ pub struct Config {
 	pub sample_rate_hz: u32,
 }
 
-/// Describes the direction audio is flowing, for a given Audio Mixer Channel.
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Direction {
-	/// Audio In, e.g. Line-In
+make_ffi_enum!("Describes the direction audio is flowing, for a given Audio Mixer Channel",
+	Direction, FfiDirection, {
+	#[doc = "Audio In, e.g. Line-In"]
 	Input,
-	/// Audio Out, e.g. Headphone Out
+	#[doc = "Audio Out, e.g. Headphone Out"]
 	Output,
-	/// Internal audio loop-back from an Input to an Output, e.g. Side-tone
-	Loopback,
-}
+	#[doc = "Internal audio loop-back from an Input to an Output, e.g. Side-tone"]
+	Loopback
+});
 
 /// Describes an Audio Mixer Channel.
 ///
@@ -91,7 +87,7 @@ pub struct MixerChannelInfo {
 	/// The name of this Audio Mixer Channel (e.g. `Line In`)
 	pub name: crate::FfiString<'static>,
 	/// Is this an Input or an Output?
-	pub direction: Direction,
+	pub direction: FfiDirection,
 	/// What value of `current_level` gives the loudest audio? All values
 	/// equal to, or above, this value will be equally and maximally loud.
 	pub max_level: u8,

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -37,7 +37,7 @@
 // ============================================================================
 
 /// Defines the format of each sample (mono, stereo, 8-bit, 16-bit, etc).
-#[repr(u8)]
+#[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SampleFormat {
 	/// 8-bit, signed, mono samples.
@@ -71,7 +71,7 @@ pub struct Config {
 }
 
 /// Describes the direction audio is flowing, for a given Audio Mixer Channel.
-#[repr(u8)]
+#[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Direction {
 	/// Audio In, e.g. Line-In

--- a/src/block_dev.rs
+++ b/src/block_dev.rs
@@ -37,7 +37,7 @@
 
 /// The types of block device we support.
 #[repr(C)]
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DeviceType {
 	/// An *SD* Card
 	SecureDigitalCard,

--- a/src/block_dev.rs
+++ b/src/block_dev.rs
@@ -23,7 +23,7 @@
 // Imports
 // ============================================================================
 
-// None
+use crate::make_ffi_enum;
 
 // ============================================================================
 // Constants
@@ -35,19 +35,17 @@
 // Types
 // ============================================================================
 
-/// The types of block device we support.
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum DeviceType {
-	/// An *SD* Card
+make_ffi_enum!("The types of block device we support",
+DeviceType, FfiDeviceType, {
+	#[doc = "An *SD* Card"]
 	SecureDigitalCard,
-	/// A Hard Drive
+	#[doc = "A Hard Drive"]
 	HardDiskDrive,
-	/// A floppy disk in a floppy disk drive
+	#[doc = "A floppy disk in a floppy disk drive"]
 	FloppyDiskDrive,
-	/// A compact flash card
-	CompactFlashCard,
-}
+	#[doc = "A compact flash card"]
+	CompactFlashCard
+});
 
 /// Information about a block device.
 #[repr(C)]
@@ -57,7 +55,7 @@ pub struct DeviceInfo {
 	/// `CF1`)
 	pub name: crate::FfiString<'static>,
 	/// The kind of block device this is.
-	pub device_type: DeviceType,
+	pub device_type: FfiDeviceType,
 	/// The size of an addressable block, in bytes.
 	pub block_size: u32,
 	/// The total number of addressable blocks.

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -24,7 +24,7 @@
 // Imports
 // ============================================================================
 
-// None
+use crate::make_ffi_enum;
 
 // ============================================================================
 // Constants
@@ -36,20 +36,18 @@
 // Types
 // ============================================================================
 
-/// The kinds of Peripheral you can put on a Neotron Bus
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum PeripheralKind {
-	/// A Neotron Bus Slot. The OS will need to read the EEPROM at address
-	/// `0x50 + slot_id` to find out what is fitted (if anything).
+make_ffi_enum!("The kinds of Peripheral you can put on a Neotron Bus",
+	PeripheralKind, FfiPeripheralKind, {
+	#[doc = "A Neotron Bus Slot.\n\nThe OS will need to read the EEPROM at address"]
+	#[doc = "`0x50 + slot_id` to find out what is fitted (if anything)."]
 	Slot,
-	/// A hard-wired SD/MMC Card slot wired for SPI Mode. The interrupt pin is
-	/// wired to "Card Detect" with a pull-up, so the line goes low when a
-	/// card is inserted and goes high when the card is removed.
+	#[doc = "A hard-wired SD/MMC Card slot wired for SPI Mode.\n\nThe interrupt pin is"]
+	#[doc = "wired to *Card Detect* with a pull-up, so the line goes low when a card is "]
+	#[doc = "inserted and goes high when the card is removed."]
 	SdCard,
-	/// This Peripheral ID is reserved for the BIOS to use.
-	Reserved,
-}
+	#[doc = "This Peripheral ID is reserved for the BIOS to use."]
+	Reserved
+});
 
 /// Describes a Neotron Bus Peripheral
 #[repr(C)]
@@ -58,7 +56,7 @@ pub struct PeripheralInfo {
 	/// A name, such as `slot0`
 	pub name: crate::FfiString<'static>,
 	/// The kind of peripheral
-	pub kind: PeripheralKind,
+	pub kind: FfiPeripheralKind,
 }
 
 // ============================================================================

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -37,8 +37,8 @@
 // ============================================================================
 
 /// The kinds of Peripheral you can put on a Neotron Bus
-#[repr(u8)]
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PeripheralKind {
 	/// A Neotron Bus Slot. The OS will need to read the EEPROM at address
 	/// `0x50 + slot_id` to find out what is fitted (if anything).

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -64,12 +64,12 @@ pub struct MouseData {
 }
 
 /// Represents the buttons on a mouse.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct MouseButtons(u8);
 
 /// Represents the LEDs on a keyboard.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct KeyboardLeds(u8);
 

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -38,7 +38,7 @@ pub use pc_keyboard::KeyCode;
 
 /// Represents a event from a Human Input Device (such as a mouse or keyboard).
 #[repr(C)]
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HidEvent {
 	/// A key was pressed.
 	KeyPress(KeyCode),

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -24,7 +24,7 @@
 // Imports
 // ============================================================================
 
-// None
+use crate::make_ffi_enum;
 
 // ============================================================================
 // Constants
@@ -36,84 +36,72 @@
 // Types
 // ============================================================================
 
-/// Identifies which sort of serial port each device represents.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum DeviceType {
-	/// An RS-232 interface
+make_ffi_enum!("Identifies which sort of serial port each device represents.",
+DeviceType, FfiDeviceType, {
+	#[doc = "An RS-232 interface"]
 	Rs232,
-	/// An RS-232 interface, but at TTL voltages. Typically used with an
-	/// FTDI FT232 cable.
+	#[doc = "An RS-232 interface, but at TTL voltages. Typically used with an "]
+	#[doc = "FTDI FT232 cable."]
 	TtlUart,
-	/// A USB Device implementing Communications Class Device (also known
-	/// as a USB Serial port). The USB Device implementation may be
-	/// on-chip, or off-chip.
+	#[doc = "A USB Device implementing Communications Class Device (also known"]
+	#[doc = "as a USB Serial port). The USB Device implementation may be"]
+	#[doc = "on-chip, or off-chip."]
 	UsbCdc,
-	/// A MIDI interface
-	Midi,
-}
+	#[doc = "A MIDI interface"]
+	Midi
+});
 
-/// Whether each word contains a parity bit, and if so, how it is
-/// calculated.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Parity {
-	/// An extra parity bit is added to each word. There will be an odd
-	/// number of `1` bits in the new word (old word + parity bit). This
-	/// parity bit can be used to detect a single bitflip in each word, but
-	/// it cannot correct that bitflip.
+make_ffi_enum!("Whether each word contains a parity bit, and if so, how it is calculated",
+	Parity, FfiParity, {
+	#[doc = "An extra parity bit is added to each word. There will be an odd"]
+	#[doc = "number of `1` bits in the new word (old word + parity bit). This"]
+	#[doc = "parity bit can be used to detect a single bitflip in each word, but"]
+	#[doc = "it cannot correct that bitflip."]
 	Odd,
-	/// An extra parity bit is added to each word. There will be an even
-	/// number of `1` bits in the new word (old word + parity bit). This
-	/// parity bit can be used to detect a single bitflip in each word, but
-	/// it cannot correct that bitflip.
+	#[doc = "An extra parity bit is added to each word. There will be an even"]
+	#[doc = "number of `1` bits in the new word (old word + parity bit). This"]
+	#[doc = "parity bit can be used to detect a single bitflip in each word, but"]
+	#[doc = "it cannot correct that bitflip."]
 	Even,
-	/// No extra parity bit is added.
-	None,
-}
+	#[doc = "No extra parity bit is added."]
+	None
+});
 
-/// Whether to use hardware handshaking lines.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Handshaking {
-	/// No hardware handshaking - bytes will be dropped if there is an
-	/// overflow
+make_ffi_enum!("Whether to use hardware handshaking lines.",
+Handshaking, FfiHandshaking, {
+	#[doc = "No hardware handshaking - bytes will be dropped if there is an overflow"]
 	None,
-	/// The Data Terminal Equipment (DTE) asserts Request-To-Send (RTS) when
-	/// it is ready to receive data, and the Data Communications Equipment
-	/// (DCE) asserts Clear-To-Send (CTS) when it is ready to receive data.
+	#[doc ="The Data Terminal Equipment (DTE) asserts Request-To-Send (RTS) when"]
+	#[doc ="it is ready to receive data, and the Data Communications Equipment "]
+	#[doc ="(DCE) asserts Clear-To-Send (CTS) when it is ready to receive data."]
 	RtsCts,
-	/// Each device will send a Transmit-Off (XOFF) byte (0x13) when its
-	/// receiving serial buffer is full, and a Transmit-On (XON) byte (0x11)
-	/// when there is buffer space and the transmission can be resumed.
-	///
-	/// Note that the driver will not replace or delete any XON or XOFF
-	/// bytes sent to the stream, so both sides must avoid sending them as
-	/// part of the normal data flow.
-	XonXoff,
-}
+	#[doc ="Each device will send a Transmit-Off (XOFF) byte (0x13) when its "]
+	#[doc ="receiving serial buffer is full, and a Transmit-On (XON) byte (0x11) "]
+	#[doc ="when there is buffer space and the transmission can be resumed. "]
+	#[doc =""]
+	#[doc ="Note that the driver will not replace or delete any XON or XOFF "]
+	#[doc ="bytes sent to the stream, so both sides must avoid sending them as "]
+	#[doc ="part of the normal data flow."]
+	XonXoff
+});
 
-/// The number of stop bits after each word.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum StopBits {
-	/// One stop bit is added to each word
+make_ffi_enum!("The number of stop bits after each word.",
+	StopBits, FfiStopBits, {
+	#[doc = "One stop bit is added to each word"]
 	One,
-	/// Two stop bits are added to each word
-	Two,
-}
+	#[doc = "Two stop bits are added to each word"]
+	Two
+});
 
-/// The number of data bits in each word sent or received by the UART.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum DataBits {
-	/// Each word comprises 7 data bits (plus start bit, stop bits and any
-	/// parity bits)
+make_ffi_enum!("The number of data bits in each word sent or received by the UART.",
+	DataBits, FfiDataBits, {
+	#[doc = "Each word comprises 7 data bits (plus start bit, stop bits and any "]
+	#[doc = "parity bits"]
 	Seven,
-	/// Each word comprises 8 data bits (plus start bit, stop bits and any
-	/// parity bits)
-	Eight,
-}
+	#[doc = "Each word comprises 8 data bits (plus start bit, stop bits and any "]
+	#[doc = "parity bits"]
+	Eight
+});
 
 /// A particular configuration for a serial port.
 #[repr(C)]
@@ -125,13 +113,13 @@ pub struct Config {
 	/// 57600 and 115200).
 	pub data_rate_bps: u32,
 	/// The desired number of data bits
-	pub data_bits: DataBits,
+	pub data_bits: FfiDataBits,
 	/// The desired number of stop bits
-	pub stop_bits: StopBits,
+	pub stop_bits: FfiStopBits,
 	/// The desired parity configuration
-	pub parity: Parity,
+	pub parity: FfiParity,
 	/// The desired handshaking configuration
-	pub handshaking: Handshaking,
+	pub handshaking: FfiHandshaking,
 }
 
 /// Information about a particular serial device.
@@ -142,7 +130,7 @@ pub struct DeviceInfo {
 	/// `USB0`)
 	pub name: crate::FfiString<'static>,
 	/// The type of this serial device
-	pub device_type: DeviceType,
+	pub device_type: FfiDeviceType,
 }
 
 // ============================================================================

--- a/src/types.rs
+++ b/src/types.rs
@@ -41,8 +41,8 @@
 pub type OsStartFn = extern "C" fn(&crate::Api) -> !;
 
 /// Any API function which can return an error, uses this error type.
-#[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
 	/// An invalid device number was given to the function.
 	InvalidDevice,
@@ -85,12 +85,28 @@ pub struct Ticks(pub u64);
 
 /// The kinds of memory we know about
 #[repr(C)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MemoryKind {
 	/// Read-write memory
+	///
+	/// The OS is free to use Ram regions.
 	Ram,
 	/// Read-only memory
+	///
+	/// The OS is free to look inside Rom regions for ROM filing systems.
 	Rom,
+	/// Used stack.
+	///
+	/// This is for information - the OS should not read or write here.
+	StackUsed,
+	/// Free stack
+	///
+	/// This is for information - the OS should not read or write here.
+	StackFree,
+	/// Reserved memory region
+	///
+	/// This is for information - the OS should not read or write here.
+	Reserved,
 }
 
 /// Represents a region in memory.
@@ -107,7 +123,7 @@ pub struct MemoryRegion {
 
 /// The kinds of power control we can do.
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PowerMode {
 	/// Turn the system power off
 	Off,
@@ -178,6 +194,9 @@ impl core::fmt::Display for MemoryKind {
 			match self {
 				MemoryKind::Rom => "ROM",
 				MemoryKind::Ram => "RAM",
+				MemoryKind::StackUsed => "StackUsed",
+				MemoryKind::StackFree => "StackFree",
+				MemoryKind::Reserved => "Reserved",
 			}
 		)
 	}

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,7 +24,7 @@
 // Imports
 // ============================================================================
 
-// None
+use crate::make_ffi_enum;
 
 // ============================================================================
 // Constants
@@ -41,24 +41,31 @@
 pub type OsStartFn = extern "C" fn(&crate::Api) -> !;
 
 /// Any API function which can return an error, uses this error type.
-#[repr(C)]
+///
+/// Errors start at 1 to leave a niche for when packing into a `Result<T,
+/// Error>`.
+#[repr(u8)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
 	/// An invalid device number was given to the function.
-	InvalidDevice,
+	InvalidDevice = 1,
 	/// That function doesn't work at this time.
 	Unimplemented,
 	/// The underlying hardware reported some error. The numeric code is BIOS
 	/// implementation specific but may give some clues.
-	DeviceError(u16),
+	DeviceError,
 	/// The underlying hardware could not accept the given configuration. The
 	/// numeric code is BIOS implementation specific but may give some clues.
-	UnsupportedConfiguration(u16),
+	UnsupportedConfiguration,
 	/// You used a Block Device API but there was no media in the drive
 	NoMediaFound,
 	/// You used a Block Device API asked for a block the device doesn't have
 	BlockOutOfBounds,
 }
+
+/// An error that specifically means 'unable to convert integer to enum'
+#[derive(Debug, Copy, Clone)]
+pub struct EnumConversionFail();
 
 /// Describes a period of time, after which the BIOS should give up.
 #[repr(C)]
@@ -83,31 +90,29 @@ pub struct Time {
 #[derive(Debug, Clone)]
 pub struct Ticks(pub u64);
 
-/// The kinds of memory we know about
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum MemoryKind {
-	/// Read-write memory
-	///
-	/// The OS is free to use Ram regions.
+make_ffi_enum!("The kinds of memory we know about",
+	MemoryKind, FfiMemoryKind, {
+	#[doc = "Read-write memory."]
+	#[doc = ""]
+	#[doc = "The OS is free to use Ram regions for code or data."]
 	Ram,
-	/// Read-only memory
-	///
-	/// The OS is free to look inside Rom regions for ROM filing systems.
+	#[doc = "Read-only memory"]
+	#[doc = ""]
+	#[doc = "The OS is free to look inside Rom regions for ROM filing systems."]
 	Rom,
-	/// Used stack.
-	///
-	/// This is for information - the OS should not read or write here.
+	#[doc = "Used stack."]
+	#[doc = ""]
+	#[doc = "This is for information - the OS should not read or write here."]
 	StackUsed,
-	/// Free stack
-	///
-	/// This is for information - the OS should not read or write here.
+	#[doc = "Free stack"]
+	#[doc = ""]
+	#[doc = "This is for information - the OS should not read or write here."]
 	StackFree,
-	/// Reserved memory region
-	///
-	/// This is for information - the OS should not read or write here.
-	Reserved,
-}
+	#[doc = "Reserved memory region"]
+	#[doc = ""]
+	#[doc = "This is for information - the OS should not read or write here."]
+	Reserved
+});
 
 /// Represents a region in memory.
 #[repr(C)]
@@ -118,23 +123,22 @@ pub struct MemoryRegion {
 	/// The length of the region
 	pub length: usize,
 	/// The kind of memory found at this region
-	pub kind: MemoryKind,
+	pub kind: FfiMemoryKind,
 }
 
-/// The kinds of power control we can do.
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum PowerMode {
-	/// Turn the system power off
+make_ffi_enum!("The kinds of power control we can do.",
+	PowerMode, FfiPowerMode, {
+	#[doc = "Turn the system power off"]
 	Off,
-	/// Reboot the main processor
+	#[doc = "Reboot the main processor"]
 	Reset,
-	/// Reboot the main processor, but tell it to enter a bootloader mode for
-	/// programming. Precisely what this will do will depend upon the BIOS. Some
-	/// BIOSes will not have a bootloader mode and this will do a regular
-	/// reboot.
-	Bootloader,
-}
+	#[doc = "Reboot the main processor, but tell it to enter a bootloader mode"]
+	#[doc = "for programming."]
+	#[doc = ""]
+	#[doc = "Precisely what this will do will depend upon the BIOS. Some BIOSes"]
+	#[doc = "will not have a bootloader mode and this will do a regular reboot."]
+	Bootloader
+});
 
 // ============================================================================
 // Impls
@@ -208,10 +212,11 @@ impl core::fmt::Display for MemoryRegion {
 	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
 		write!(
 			f,
-			"{} KiB {} @ {:p}",
+			"{} KiB {} @ {:p}..{:p}",
 			self.length / 1024,
-			self.kind,
-			self.start
+			self.kind.make_safe().unwrap_or(MemoryKind::Reserved),
+			self.start,
+			unsafe { self.start.add(self.length) },
 		)
 	}
 }

--- a/src/video.rs
+++ b/src/video.rs
@@ -37,6 +37,7 @@
 // ============================================================================
 
 /// The set of errors you can get from this module.
+#[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Error {
 	/// You supplied a parameter that was out of range, or otherwise unsupported.
@@ -52,7 +53,7 @@ pub enum Error {
 pub struct Mode(u8);
 
 /// Describes the format of the video memory.
-#[repr(u8)]
+#[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Format {
 	/// Text mode with an 8x16 font.
@@ -102,7 +103,7 @@ pub enum Format {
 }
 
 /// Describes the timing of the video signal.
-#[repr(u8)]
+#[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Timing {
 	/// VGA Standard 640x480 @ 60Hz.
@@ -124,7 +125,7 @@ pub enum Timing {
 
 /// Describes how a video mode is caled
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Scaling {
 	/// No video scaling
 	None,

--- a/src/video.rs
+++ b/src/video.rs
@@ -530,6 +530,68 @@ impl RGBColour {
 	}
 }
 
+impl TextForegroundColour {
+	/// Convert a foreground colour into a background colour
+	pub const fn make_background(self) -> TextBackgroundColour {
+		match self {
+			TextForegroundColour::Black => TextBackgroundColour::Black,
+			TextForegroundColour::Blue => TextBackgroundColour::Blue,
+			TextForegroundColour::Green => TextBackgroundColour::Green,
+			TextForegroundColour::Cyan => TextBackgroundColour::Cyan,
+			TextForegroundColour::Red => TextBackgroundColour::Red,
+			TextForegroundColour::Magenta => TextBackgroundColour::Magenta,
+			TextForegroundColour::Brown => TextBackgroundColour::Brown,
+			TextForegroundColour::LightGray => TextBackgroundColour::LightGray,
+			TextForegroundColour::DarkGray => TextBackgroundColour::Black,
+			TextForegroundColour::LightBlue => TextBackgroundColour::Blue,
+			TextForegroundColour::LightGreen => TextBackgroundColour::Green,
+			TextForegroundColour::LightCyan => TextBackgroundColour::Cyan,
+			TextForegroundColour::LightRed => TextBackgroundColour::Red,
+			TextForegroundColour::Pink => TextBackgroundColour::Magenta,
+			TextForegroundColour::Yellow => TextBackgroundColour::Brown,
+			TextForegroundColour::White => TextBackgroundColour::LightGray,
+		}
+	}
+
+	/// Convert to the brighter version of the same shade
+	pub const fn brighten(self) -> TextForegroundColour {
+		match self {
+			TextForegroundColour::Black => TextForegroundColour::DarkGray,
+			TextForegroundColour::Red => TextForegroundColour::LightRed,
+			TextForegroundColour::Green => TextForegroundColour::LightGreen,
+			TextForegroundColour::Brown => TextForegroundColour::Yellow,
+			TextForegroundColour::Blue => TextForegroundColour::LightBlue,
+			TextForegroundColour::Magenta => TextForegroundColour::Pink,
+			TextForegroundColour::Cyan => TextForegroundColour::LightCyan,
+			TextForegroundColour::LightGray => TextForegroundColour::White,
+			TextForegroundColour::DarkGray => TextForegroundColour::LightGray,
+			TextForegroundColour::LightBlue => TextForegroundColour::LightBlue,
+			TextForegroundColour::LightGreen => TextForegroundColour::LightGreen,
+			TextForegroundColour::LightCyan => TextForegroundColour::LightCyan,
+			TextForegroundColour::LightRed => TextForegroundColour::LightRed,
+			TextForegroundColour::Pink => TextForegroundColour::Pink,
+			TextForegroundColour::Yellow => TextForegroundColour::Yellow,
+			TextForegroundColour::White => TextForegroundColour::White,
+		}
+	}
+}
+
+impl TextBackgroundColour {
+	/// Convert a background colour into a foreground colour
+	pub const fn make_foreground(self) -> TextForegroundColour {
+		match self {
+			TextBackgroundColour::Black => TextForegroundColour::Black,
+			TextBackgroundColour::Blue => TextForegroundColour::Blue,
+			TextBackgroundColour::Green => TextForegroundColour::Green,
+			TextBackgroundColour::Cyan => TextForegroundColour::Cyan,
+			TextBackgroundColour::Red => TextForegroundColour::Red,
+			TextBackgroundColour::Magenta => TextForegroundColour::Magenta,
+			TextBackgroundColour::Brown => TextForegroundColour::Brown,
+			TextBackgroundColour::LightGray => TextForegroundColour::LightGray,
+		}
+	}
+}
+
 impl Attr {
 	/// Make a new Attribute Value.
 	///

--- a/src/video.rs
+++ b/src/video.rs
@@ -24,7 +24,7 @@
 // Imports
 // ============================================================================
 
-// None
+use crate::make_ffi_enum;
 
 // ============================================================================
 // Constants
@@ -36,14 +36,6 @@
 // Types
 // ============================================================================
 
-/// The set of errors you can get from this module.
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Error {
-	/// You supplied a parameter that was out of range, or otherwise unsupported.
-	BadParam,
-}
-
 /// Describes a video mode.
 ///
 /// A Neotron BIOS may support multiple video modes. Each is described using
@@ -52,55 +44,53 @@ pub enum Error {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Mode(u8);
 
-/// Describes the format of the video memory.
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Format {
-	/// Text mode with an 8x16 font.
-	///
-	/// Memory is arranged into `(u8, u8)` units. The first `u8` is the
-	/// character, the second `u8` unit is the foreground/background colour.
-	///
-	/// The font consists of 8px by 16px glyphs.
-	Text8x16 = 0,
-	/// Text mode with an 8x8 font.
-	///
-	/// Memory is arranged into `(u8, u8)` units. The first `u8` is the
-	/// character, the second `u8` unit is the foreground/background colour.
-	///
-	/// The font consists of 8px by 8px glyphs.
-	Text8x8 = 1,
-	/// True-colour graphics mode, with 24-bit pixels in 32-bit units.
-	///
-	/// Memory is arranged into `u32` units. Each unit is of the format
-	/// `0x00RRGGBB`.
-	Chunky32 = 2,
-	/// High-colour graphics mode, with 16-bit pixels.
-	///
-	/// Memory is arranged into `u16` units. Each unit is of the format
-	/// `0bRRRRR_GGGGGG_BBBBB`.
-	Chunky16 = 3,
-	/// Colour graphics mode, with 8-bit indexed pixels.
-	///
-	/// Memory is arranged into `u8` units. Each unit is a lookup into the
-	/// pallette.
-	Chunky8 = 4,
-	/// Colour graphics mode, with 4-bit indexed pixels.
-	///
-	/// Memory is arranged into `u8` units. Each unit is two 4-bit pixels,
-	/// each a lookup into the pallette, or `0bAAAA_BBBB`.
-	Chunky4 = 5,
-	/// Colour graphics mode, with 2-bit indexed pixels.
-	///
-	/// Memory is arranged into `u8` units. Each unit is four 2-bit pixels,
-	/// each a lookup into the pallette, or `0bAA_BB_CC_DD`
-	Chunky2 = 6,
-	/// Mono graphics mode, with 1-bit per pixel.
-	///
-	/// Memory is arranged into `u8` units. Each unit is eight 1-bit pixels,
-	/// each a lookup into the pallette, or `0bA_B_C_D_E_F_G_H`
-	Chunky1 = 7,
-}
+make_ffi_enum!("Describes the format of the video memory.",
+	Format, FfiFormat, {
+	#[doc = "Text mode with an 8x16 font."]
+	#[doc = ""]
+	#[doc = "Memory is arranged into `(u8, u8)` units. The first `u8` is the"]
+	#[doc = "character, the second `u8` unit is the foreground/background colour."]
+	#[doc = ""]
+	#[doc = "The font consists of 8px by 16px glyphs."]
+	Text8x16,
+	#[doc = "Text mode with an 8x8 font."]
+	#[doc = ""]
+	#[doc = "Memory is arranged into `(u8, u8)` units. The first `u8` is the"]
+	#[doc = "character, the second `u8` unit is the foreground/background colour."]
+	#[doc = ""]
+	#[doc = "The font consists of 8px by 8px glyphs."]
+	Text8x8,
+	#[doc = "True-colour graphics mode, with 24-bit pixels in 32-bit units."]
+	#[doc = ""]
+	#[doc = "Memory is arranged into `u32` units. Each unit is of the format"]
+	#[doc = "`0x00RRGGBB`."]
+	Chunky32,
+	#[doc = "High-colour graphics mode, with 16-bit pixels."]
+	#[doc = ""]
+	#[doc = "Memory is arranged into `u16` units. Each unit is of the format"]
+	#[doc = "`0bRRRRR_GGGGGG_BBBBB`."]
+	Chunky16,
+	#[doc = "Colour graphics mode, with 8-bit indexed pixels."]
+	#[doc = ""]
+	#[doc = "Memory is arranged into `u8` units. Each unit is a lookup into the"]
+	#[doc = "palette."]
+	Chunky8,
+	#[doc = "Colour graphics mode, with 4-bit indexed pixels."]
+	#[doc = ""]
+	#[doc = "Memory is arranged into `u8` units. Each unit is two 4-bit pixels,"]
+	#[doc = "each a lookup into the palette, or `0bAAAA_BBBB`."]
+	Chunky4,
+	#[doc = "Colour graphics mode, with 2-bit indexed pixels."]
+	#[doc = ""]
+	#[doc = "Memory is arranged into `u8` units. Each unit is four 2-bit pixels,"]
+	#[doc = "each a lookup into the palette, or `0bAA_BB_CC_DD`"]
+	Chunky2,
+	#[doc = "Mono graphics mode, with 1-bit per pixel."]
+	#[doc = ""]
+	#[doc = "Memory is arranged into `u8` units. Each unit is eight 1-bit pixels,"]
+	#[doc = "each a lookup into the palette, or `0bA_B_C_D_E_F_G_H`"]
+	Chunky1
+});
 
 /// Describes the timing of the video signal.
 #[repr(C)]
@@ -147,19 +137,61 @@ pub struct RGBColour(u32);
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Glyph(pub u8);
 
-/// Represents a pallette index that we can use as a text foreground colour.
-///
-/// Only supports the range `0..=15`
-#[repr(transparent)]
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub struct TextForegroundColour(u8);
+make_ffi_enum!("Text-mode foreground colour value.",
+	TextForegroundColour, FfiTextForegroundColour, {
+	#[doc = "Black (palette 0)"]
+	Black,
+	#[doc = "Blue (palette 1)"]
+	Blue,
+	#[doc = "Green (palette 2)"]
+	Green,
+	#[doc = "Cyan (palette 3)"]
+	Cyan,
+	#[doc = "Red (palette 4)"]
+	Red,
+	#[doc = "Magenta (palette 5)"]
+	Magenta,
+	#[doc = "Brown (palette 6)"]
+	Brown,
+	#[doc = "Light Gray (palette 7)"]
+	LightGray,
+	#[doc = "Dark Gray (palette 8)"]
+	DarkGray,
+	#[doc = "Light Blue (palette 9)"]
+	LightBlue,
+	#[doc = "Light Green (palette 10)"]
+	LightGreen,
+	#[doc = "Light Cyan (palette 11)"]
+	LightCyan,
+	#[doc = "Light Red (palette 12)"]
+	LightRed,
+	#[doc = "Pink (palette 13)"]
+	Pink,
+	#[doc = "Yellow (palette 14)"]
+	Yellow,
+	#[doc = "White (palette 15)"]
+	White
+});
 
-/// Represents a pallette index that we can use as a text background colour.
-///
-/// Only supports the range `0..=7`
-#[repr(transparent)]
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub struct TextBackgroundColour(u8);
+make_ffi_enum!("Text-mode background colour value.",
+	TextBackgroundColour, FfiTextBackgroundColour, {
+	#[doc = "Black (palette 0)"]
+	Black,
+	#[doc = "Blue (palette 1)"]
+	Blue,
+	#[doc = "Green (palette 2)"]
+	Green,
+	#[doc = "Cyan (palette 2)"]
+	Cyan,
+	#[doc = "Red (palette 3)"]
+	Red,
+	#[doc = "Magenta (palette 4)"]
+	Magenta,
+	#[doc = "Brown (palette 5)"]
+	Brown,
+	#[doc = "Light Gray (palette 6)"]
+	LightGray
+});
 
 /// Represents VGA format foreground/background attributes.
 #[repr(transparent)]
@@ -498,121 +530,6 @@ impl RGBColour {
 	}
 }
 
-impl TextForegroundColour {
-	/// The highest value a VGA text-mode foreground colour can have.
-	pub const MAX: u8 = 15;
-
-	/// The colour *Black* in the default palette
-	pub const BLACK: Self = Self(0);
-	/// The colour *Blue* in the default palette
-	pub const BLUE: Self = Self(1);
-	/// The colour *Green* in the default palette
-	pub const GREEN: Self = Self(2);
-	/// The colour *Cyan* in the default palette
-	pub const CYAN: Self = Self(3);
-	/// The colour *Red* in the default palette
-	pub const RED: Self = Self(4);
-	/// The colour *Magenta* in the default palette
-	pub const MAGENTA: Self = Self(5);
-	/// The colour *Brown* in the default palette
-	pub const BROWN: Self = Self(6);
-	/// The colour *Light Gray* in the default palette
-	pub const LIGHT_GRAY: Self = Self(7);
-	/// The colour *Dark Gray* in the default palette
-	pub const DARK_GRAY: Self = Self(8);
-	/// The colour *Light Blue* in the default palette
-	pub const LIGHT_BLUE: Self = Self(9);
-	/// The colour *Light Green* in the default palette
-	pub const LIGHT_GREEN: Self = Self(10);
-	/// The colour *Light Cyan* in the default palette
-	pub const LIGHT_CYAN: Self = Self(11);
-	/// The colour *Light Red* in the default palette
-	pub const LIGHT_RED: Self = Self(12);
-	/// The colour *Pink* in the default palette
-	pub const PINK: Self = Self(13);
-	/// The colour *Yellow* in the default palette
-	pub const YELLOW: Self = Self(14);
-	/// The colour *White* in the default palette
-	pub const WHITE: Self = Self(15);
-
-	/// Make a new `TextForegroundColour` from an integer.
-	///
-	/// The value must be `<= Self::MAX`, or you will get an error.
-	#[inline]
-	pub const fn new(value: u8) -> Result<Self, Error> {
-		if value <= Self::MAX {
-			Ok(Self(value))
-		} else {
-			Err(Error::BadParam)
-		}
-	}
-
-	/// Make a new `TextForegroundColour` from an integer without bounds checking.
-	///
-	/// # Safety
-	///
-	/// The value must be `<= Self::MAX`, or you will get undefined behaviour.
-	#[inline]
-	pub const unsafe fn new_unchecked(value: u8) -> Self {
-		Self(value)
-	}
-
-	/// Convert to a raw integer
-	#[inline]
-	pub const fn as_u8(self) -> u8 {
-		self.0
-	}
-}
-
-impl TextBackgroundColour {
-	/// The highest value a VGA text-mode background colour can have.
-	pub const MAX: u8 = 7;
-
-	/// The colour *Black* in the default palette
-	pub const BLACK: Self = Self(0);
-	/// The colour *Blue* in the default palette
-	pub const BLUE: Self = Self(1);
-	/// The colour *Green* in the default palette
-	pub const GREEN: Self = Self(2);
-	/// The colour *Cyan* in the default palette
-	pub const CYAN: Self = Self(3);
-	/// The colour *Red* in the default palette
-	pub const RED: Self = Self(4);
-	/// The colour *Magenta* in the default palette
-	pub const MAGENTA: Self = Self(5);
-	/// The colour *Brown* in the default palette
-	pub const BROWN: Self = Self(6);
-	/// The colour *Light Gray* in the default palette
-	pub const LIGHT_GRAY: Self = Self(7);
-
-	/// Make a new TextForegroundColour from an integer.
-	///
-	/// The value must be `<= Self::MAX`, or you will get an error.
-	#[inline]
-	pub const fn new(value: u8) -> Result<Self, Error> {
-		if value <= Self::MAX {
-			Ok(Self(value))
-		} else {
-			Err(Error::BadParam)
-		}
-	}
-
-	/// Make a new TextForegroundColour from an integer without bounds checking.
-	///
-	/// # Safety
-	///
-	/// The value must be `<= Self::MAX`, or you will get undefined behaviour.
-	pub const unsafe fn new_unchecked(value: u8) -> Self {
-		Self(value)
-	}
-
-	/// Convert to a raw integer
-	#[inline]
-	pub const fn as_u8(self) -> u8 {
-		self.0
-	}
-}
-
 impl Attr {
 	/// Make a new Attribute Value.
 	///
@@ -627,8 +544,8 @@ impl Attr {
 	/// ```
 	#[inline]
 	pub const fn new(fg: TextForegroundColour, bg: TextBackgroundColour, blink: bool) -> Attr {
-		let fg = fg.0 & 0b1111;
-		let bg = (bg.0 & 0b111) << 4;
+		let fg = fg as u8 & 0b1111;
+		let bg = (bg as u8 & 0b111) << 4;
 		let blink = if blink { 1 << 7 } else { 0 };
 		let value = blink | bg | fg;
 		Attr(value)
@@ -637,13 +554,23 @@ impl Attr {
 	/// Get the foreground colour
 	#[inline]
 	pub const fn fg(&self) -> TextForegroundColour {
-		TextForegroundColour(self.0 & 0x0F)
+		match FfiTextForegroundColour(self.0 & 0x0F).make_safe() {
+			Ok(v) => v,
+			Err(_e) => {
+				panic!("Failed conversion")
+			}
+		}
 	}
 
 	/// Get the background colour
 	#[inline]
 	pub const fn bg(&self) -> TextBackgroundColour {
-		TextBackgroundColour((self.0 >> 4) & 0x07)
+		match FfiTextBackgroundColour((self.0 >> 4) & 0x07).make_safe() {
+			Ok(v) => v,
+			Err(_e) => {
+				panic!("Failed conversion")
+			}
+		}
 	}
 
 	/// Is the text blinking?


### PR DESCRIPTION
Also rationalise all enum types as repr(C) for easier interfacing with C code.